### PR TITLE
Added support for gpt-4-1106-preview model

### DIFF
--- a/qq.py
+++ b/qq.py
@@ -94,6 +94,7 @@ supported_models = [
     "gpt-4",
     "gpt-3.5-turbo-16k",
     "gpt-4-32k",
+    "gpt-4-1106-preview",
 ]
 
 def setup_database():


### PR DESCRIPTION
Just adds the model to the list of supported models, no changes in functionality yet, but this will remove the warning on unsupported models.

First tests show a 2-3x speedup in getting commands (with similar quality), a 3-4x speedup for explanations, with explanations being more thorough and giving examples.